### PR TITLE
Fix: tweet quote opens multiple windows

### DIFF
--- a/Day13/app.js
+++ b/Day13/app.js
@@ -18,14 +18,14 @@ async function quote() {
     `;
 
 	document.querySelector('.content').append(quote);
-
-	tweetQuote.addEventListener('click', () => {
-		window.open(`https://twitter.com/intent/tweet/?text=${newQuote.content}`);
-	});
 }
 
 newQuote.addEventListener('click', () => {
 	quote();
+});
+
+tweetQuote.addEventListener('click', () => {
+	newQuote.content && window.open(`https://twitter.com/intent/tweet/?text=${newQuote.content}`);
 });
 
 quote();


### PR DESCRIPTION
- moved event wiring `addEventListener` outside `quote` function.